### PR TITLE
chore: refresh base image for USN-8155

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Build an image from Dockerfile
         run: |
-          docker build --file Dockerfile --tag conplementag/cops-controller:${{ github.sha }} .
+          docker build --pull --file Dockerfile --tag conplementag/cops-controller:${{ github.sha }} .
 
       - name: Download and install syft
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build & Push Docker image
         if: ${{ steps.release.outputs.release_created }}
         run: |
-          docker build . --file Dockerfile --tag conplementag/cops-controller:v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
+          docker build --pull . --file Dockerfile --tag conplementag/cops-controller:v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
           docker push conplementag/cops-controller:v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
       - name: Download chart releaser
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
- always pull latest base images in the pipeline
- this commit should also bump the version so we can publish new package with downstream vulnerability fixes
- https://ubuntu.com/security/notices/USN-8155-1#details
